### PR TITLE
Change snapshot key name

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
     "node": true,
     "es2021": true
   },
-  "extends": ["plugin:import/recommended", "airbnb-typescript/base"],
+  "extends": ["plugin:import/recommended", "airbnb-typescript/base", "prettier"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     // required for "type-aware linting"
@@ -25,20 +25,6 @@
     "@typescript-eslint/comma-dangle": "off",
     "indent": "off",
     "@typescript-eslint/indent": "off",
-    // prettier config
-    "prettier/prettier": [
-      1,
-      {
-        "printWidth": 100,
-        "endOfLine": "auto",
-        "tabWidth": 2,
-        "useTabs": false,
-        "singleQuote": true,
-        "semi": true,
-        "arrowParens": "avoid",
-        "singleAttributePerLine": true
-      }
-    ],
     "import/order": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,70 +1,59 @@
 {
-    "env": {
-        "node": true,
-        "es2021": true
-    },
-    "extends": [
-        "plugin:import/recommended",
-        "airbnb-typescript/base"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        // required for "type-aware linting"
-        "project": [
-            "./tsconfig.json"
-        ],
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "import",
-        "@typescript-eslint",
-        "prettier"
-    ],
-    "settings": {
-        // resolves imports without file extensions for listed extensions
-        "import/resolver": {
-            "node": {
-                "extensions": [
-                    ".ts"
-                ]
-            }
-        }
-    },
-    "rules": {
-        "comma-dangle": "off",
-        "@typescript-eslint/comma-dangle": "off",
-        "indent": "off",
-        "@typescript-eslint/indent": "off",
-        // prettier config
-        "prettier/prettier": [
-            1,
-            {
-                "printWidth": 100,
-                "endOfLine": "auto",
-                "tabWidth": 2,
-                "useTabs": false,
-                "singleQuote": true,
-                "semi": true,
-                "arrowParens": "avoid",
-                "singleAttributePerLine": true
-            }
-        ],
-        "import/order": [
-            "error", 
-            { 
-                "alphabetize": { 
-                    "order": "asc",
-                    "caseInsensitive": false
-                }
-            }
-        ],
-        "import/extensions": [0],
-        // var rules
-        "no-use-before-define": "off",
-        "@typescript-eslint/no-use-before-define": "error",
-        "@typescript-eslint/no-unused-vars": "warn",
-        // class rules
-        "@typescript-eslint/lines-between-class-members": "off"
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["plugin:import/recommended", "airbnb-typescript/base"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    // required for "type-aware linting"
+    "project": ["./tsconfig.json"],
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["import", "@typescript-eslint", "prettier"],
+  "settings": {
+    // resolves imports without file extensions for listed extensions
+    "import/resolver": {
+      "node": {
+        "extensions": [".ts"]
+      }
     }
+  },
+  "rules": {
+    "comma-dangle": "off",
+    "@typescript-eslint/comma-dangle": "off",
+    "indent": "off",
+    "@typescript-eslint/indent": "off",
+    // prettier config
+    "prettier/prettier": [
+      1,
+      {
+        "printWidth": 100,
+        "endOfLine": "auto",
+        "tabWidth": 2,
+        "useTabs": false,
+        "singleQuote": true,
+        "semi": true,
+        "arrowParens": "avoid",
+        "singleAttributePerLine": true
+      }
+    ],
+    "import/order": [
+      "error",
+      {
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": false
+        }
+      }
+    ],
+    "import/extensions": [0],
+    // var rules
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": "error",
+    "@typescript-eslint/no-unused-vars": "warn",
+    // class rules
+    "@typescript-eslint/lines-between-class-members": "off"
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "printWidth": 100,
+  "endOfLine": "auto",
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true,
+  "semi": true,
+  "arrowParens": "avoid",
+  "singleAttributePerLine": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fractal-subgraph",
-  "version": "0.2.0",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fractal-subgraph",
-      "version": "0.2.0",
+      "version": "0.0.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@graphprotocol/graph-cli": "^0.69.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fractal-subgraph",
   "license": "UNLICENSED",
-  "version": "0.2.0",
+  "version": "0.0.2",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",

--- a/schema.graphql
+++ b/schema.graphql
@@ -5,5 +5,5 @@ type DAO @entity(immutable: false) {
   name: String
   hierarchy: [DAO!]!
   proposalTemplatesHash: String # IPFS Hash
-  snapshotURL: String
+  snapshotENS: String
 }

--- a/src/key-value-pairs.ts
+++ b/src/key-value-pairs.ts
@@ -13,14 +13,14 @@ export function handleValueUpdated(event: ValueUpdatedEvent): void {
       dao.proposalTemplatesHash = event.params.value;
       dao.save();
     }
-  } else if (event.params.key == 'snapshotURL') {
+  } else if (event.params.key == 'snapshotENS') {
     let dao = DAO.load(event.params.theAddress);
     if (dao) {
-      log.info('Processing Snapshot URL for DAO: {}, the URL is: {}', [
+      log.info('Processing Snapshot ENS for DAO: {}, the ENS is: {}', [
         event.params.theAddress.toHexString(),
         event.params.value,
       ]);
-      dao.snapshotURL = event.params.value;
+      dao.snapshotENS = event.params.value;
       dao.save();
     }
   } else {


### PR DESCRIPTION
- Changed `KeyValuePairs` event listener to look for events with key name `snapshotENS`, not `snapshotURL`.
- Changed subgraph's DAO entity property name from `snapshotURL` to `subgraphENS`.
- Deployed new changes to all networks, with a version of `0.0.2`