### PR TITLE
Create dao on snapshot ens

### DIFF
--- a/src/fractal-registry.ts
+++ b/src/fractal-registry.ts
@@ -1,21 +1,8 @@
-import { Bytes } from '@graphprotocol/graph-ts';
 import {
   FractalNameUpdated as FractalNameUpdatedEvent,
   FractalSubDAODeclared as FractalSubDAODeclaredEvent,
 } from '../generated/FractalRegistry/FractalRegistry';
-import { DAO } from '../generated/schema';
-
-const loadOrCreateDAO = (address: Bytes): DAO => {
-  const existingDao = DAO.load(address); // Using address as ID
-  if (existingDao) {
-    return existingDao;
-  }
-
-  const newDao = new DAO(address);
-  newDao.address = address; // But also keep address field on DAO entity in case we would want to use something else as ID
-  newDao.hierarchy = [];
-  return newDao;
-};
+import { loadOrCreateDAO } from './shared';
 
 export function handleFractalNameUpdated(event: FractalNameUpdatedEvent): void {
   const dao = loadOrCreateDAO(event.params.daoAddress);

--- a/src/key-value-pairs.ts
+++ b/src/key-value-pairs.ts
@@ -1,29 +1,23 @@
 import { log } from '@graphprotocol/graph-ts';
 import { ValueUpdated as ValueUpdatedEvent } from '../generated/KeyValuePairs/KeyValuePairs';
-import { DAO } from '../generated/schema';
+import { loadOrCreateDAO } from './shared';
 
 export function handleValueUpdated(event: ValueUpdatedEvent): void {
-  if (event.params.key == 'proposalTemplates') {
-    let dao = DAO.load(event.params.theAddress);
-    if (dao) {
-      log.info('Processing proposal templates for DAO: {}, the IPFS hash is: {}', [
-        event.params.theAddress.toHexString(),
-        event.params.value,
-      ]);
+  switch (event.params.key) {
+    case 'proposalTemplates': {
+      const dao = loadOrCreateDAO(event.params.theAddress);
       dao.proposalTemplatesHash = event.params.value;
       dao.save();
+      break;
     }
-  } else if (event.params.key == 'snapshotENS') {
-    let dao = DAO.load(event.params.theAddress);
-    if (dao) {
-      log.info('Processing Snapshot ENS for DAO: {}, the ENS is: {}', [
-        event.params.theAddress.toHexString(),
-        event.params.value,
-      ]);
+    case 'snapshotENS': {
+      const dao = loadOrCreateDAO(event.params.theAddress);
       dao.snapshotENS = event.params.value;
       dao.save();
+      break;
     }
-  } else {
-    log.warning('Unknown key: {}', [event.params.key]);
+    default: {
+      log.warning('Unknown key: {}', [event.params.key]);
+    }
   }
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,14 @@
+import { Bytes } from '@graphprotocol/graph-ts';
+import { DAO } from '../generated/schema';
+
+export const loadOrCreateDAO = (address: Bytes): DAO => {
+  const existingDao = DAO.load(address); // Using address as ID
+  if (existingDao) {
+    return existingDao;
+  }
+
+  const newDao = new DAO(address);
+  newDao.address = address; // But also keep address field on DAO entity in case we would want to use something else as ID
+  newDao.hierarchy = [];
+  return newDao;
+};


### PR DESCRIPTION
When setting `proposalTemplates` or `snapshotENS` via a call to the `KeyValuePairs` contract, if a Subgraph DAO object doesn't yet exist for that Safe, create one.

This covers the case when a Safe is created via Safe UI, and then the _very first thing_ someone does to that Safe in the Decent UI is add a Snapshot ENS.

Previously, the Safe address was not indexed in Subgraph yet, and we only attempted to "load" the DAO object (not create one if it doesn't exist), so setting the Snapshot ENS silently failed.